### PR TITLE
Bug fixed: variables with the value 0 were not shown

### DIFF
--- a/src/templayed.js
+++ b/src/templayed.js
@@ -22,7 +22,7 @@ templayed = function(template, vars) {
     return template.replace(/\{\{(!|&|\{)?\s*(.*?)\s*}}+/g, function(match, operator, context) {
       if (operator == "!") return '';
       var i = inc++;
-      return ['"; var o', i, ' = ', get(context), ', s', i, ' = (((typeof(o', i, ') == "function" ? o', i, '.call(vars[vars.length - 1]) : o', i, ') || "") + ""); s += ',
+      return ['"; var o', i, ' = ', get(context), ', s', i, ' = typeof(o', i, ') == "function" ? o', i, '.call(vars[vars.length - 1]) : o', i, '; s', i,' = ( s', i,' || s', i,' == 0 ? s', i,': "") + ""; s += ',
         (operator ? ('s' + i) : '(/[&"><]/.test(s' + i + ') ? s' + i + '.replace(/&/g,"&amp;").replace(/"/g,"&quot;").replace(/>/g,"&gt;").replace(/</g,"&lt;") : s' + i + ')'), ' + "'
       ].join('');
     });

--- a/test/assets/tests.js
+++ b/test/assets/tests.js
@@ -176,6 +176,11 @@ var inspect = function(object) {
         variables = {two: 2, three: 3},
         expected  = "1, 2, 3!";
     equal(templayed(template)(variables), expected, inspect(template) + ", " + inspect(variables));
+    
+    template  = "{{zero}}!",
+    variables = {zero: 0},
+    expected  = "0!";
+    equal(templayed(template)(variables), expected, inspect(template) + ", " + inspect(variables));
   });
 
   test("Quote escaping", function() {


### PR DESCRIPTION
Before this fix:

```
templayed("{{zero}}")({"zero": 0}) === ""
```

now:

```
templayed("{{zero}}")({"zero": 0}) === "0"
```

I have also added a unit test for this case in tests.js
