### PR TITLE
fixed bug replace | with \n

### DIFF
--- a/src/templayed.js
+++ b/src/templayed.js
@@ -37,7 +37,7 @@ templayed = function(template, vars) {
     }));
   }, inc = 0;
 
-  return new Function('vars', 's', 'vars = [vars], s = "' + block(template.replace(/"/g, '\\"').replace(/[\n|\r\n]/g, '\\n')) + '"; return s;');
+  return new Function('vars', 's', 'vars = [vars], s = "' + block(template.replace(/"/g, '\\"').replace(/\n|\r\n/g, '\\n')) + '"; return s;');
 };
 
 templayed.version = '{version}';


### PR DESCRIPTION
```js
"aa||bb".replace(/[\n|\r\n]/g, '\\n')
// aa\n\nbb
```