### PR TITLE
Allow length checks

### DIFF
--- a/src/templayed.js
+++ b/src/templayed.js
@@ -11,34 +11,36 @@ if (typeof(templayed) == "undefined") {
 // *
 
 templayed = function(template, vars) {
-
   var get = function(path, i) {
     i = 1; path = path.replace(/\.\.\//g, function() { i++; return ''; });
     var js = ['vars[vars.length - ', i, ']'], keys = (path == "." ? [] : path.split(".")), j = 0;
     for (j; j < keys.length; j++) { js.push('.' + keys[j]); };
     return js.join('');
-  }, tag = function(template) {
-    return template.replace(/\{\{(!|&|\{)?\s*(.*?)\s*}}+/g, function(match, operator, context) {
+  },tag = function(template) {
+    return template.replace(/\{\{(!|&|\{)?\s*(.*?)\s*}}+/g, function(_, operator, context) {
       if (operator == "!") return '';
       var i = inc++;
       return ['"; var o', i, ' = ', get(context), ', s', i, ' = typeof(o', i, ') == "function" ? o', i, '.call(vars[vars.length - 1]) : o', i, '; s', i,' = ( s', i,' || s', i,' == 0 ? s', i,': "") + ""; s += ',
         (operator ? ('s' + i) : '(/[&"><]/.test(s' + i + ') ? s' + i + '.replace(/&/g,"&amp;").replace(/"/g,"&quot;").replace(/>/g,"&gt;").replace(/</g,"&lt;") : s' + i + ')'), ' + "'
       ].join('');
     });
-  }, block = function(template) {
-    return tag(template.replace(/\{\{(\^|#)(.*?)}}(.*?)\{\{\/\2}}/g, function(match, operator, key, context) {
-      var i = inc++;
-      return ['"; var o', i, ' = ', get(key), '; ',
-        (operator == "^" ?
-          ['if ((o', i, ' instanceof Array) ? !o', i, '.length : !o', i, ') { s += "', block(context), '"; } '] :
-          ['if (typeof(o', i, ') == "boolean" && o', i, ') { s += "', block(context), '"; } else if (o', i, ') { for (var i', i, ' = 0; i', i, ' < o',
-            i, '.length; i', i, '++) { vars.push(o', i, '[i', i, ']); s += "', block(context), '"; vars.pop(); }}']
-        ).join(''), '; s += "'].join('');
+  },lengthCheck = function(key, context, truthy = true) {
+    return ['if (',(truthy ? '' : '!'), get(key.split('.')[0]),'.length) { s += "', context, '";}'];
+  },block = function(template) {
+    return tag(template.replace(/\{\{(\^|#|\+)(.*?)}}(.*?)\{\{\/\2}}/g, function(_, operator, key, context) {
+      var i = inc++,
+        context = block(context)
+        logic = ['if (typeof(o', i, ') == "boolean" && o', i, ') { s += "', context, '"; } else if (o', i, ') { for (var i', i, ' = 0; i', i, ' < o', i, '.length; i', i, '++) { vars.push(o', i, '[i', i, ']); s += "', context, '"; vars.pop(); }}'];
+      
+      if (/(.*)\.length$/gi.test(key)) { logic = lengthCheck(key, context, operator != '^'); }
+      else if (operator == '^') { logic = ['if ((o', i, ' instanceof Array) ? !o', i, '.length : !o', i, ') { s += "', context, '"; } ']; }
+      
+      return ['"; var o', i, ' = ', get(key), '; ', logic.join(''), '; s += "'].join('');
     }));
-  }, inc = 0;
+  },inc = 0; 
 
   return new Function('vars', 's', 'vars = [vars], s = "' + block(template.replace(/"/g, '\\"').replace(/(\n|\r\n)/g, '\\n')) + '"; return s;');
-};
+}; 
 
 templayed.version = '{version}';
 

--- a/src/templayed.js
+++ b/src/templayed.js
@@ -29,7 +29,7 @@ templayed = function(template, vars) {
   },block = function(template) {
     return tag(template.replace(/\{\{(\^|#|\+)(.*?)}}(.*?)\{\{\/\2}}/g, function(_, operator, key, context) {
       var i = inc++,
-        context = block(context)
+        context = block(context),
         logic = ['if (typeof(o', i, ') == "boolean" && o', i, ') { s += "', context, '"; } else if (o', i, ') { for (var i', i, ' = 0; i', i, ' < o', i, '.length; i', i, '++) { vars.push(o', i, '[i', i, ']); s += "', context, '"; vars.pop(); }}'];
       
       if (/(.*)\.length$/gi.test(key)) { logic = lengthCheck(key, context, operator != '^'); }

--- a/src/templayed.js
+++ b/src/templayed.js
@@ -37,10 +37,10 @@ templayed = function(template, vars) {
       
       return ['"; var o', i, ' = ', get(key), '; ', logic.join(''), '; s += "'].join('');
     }));
-  },inc = 0; 
+  },inc = 0;
 
   return new Function('vars', 's', 'vars = [vars], s = "' + block(template.replace(/"/g, '\\"').replace(/(\n|\r\n)/g, '\\n')) + '"; return s;');
-}; 
+};
 
 templayed.version = '{version}';
 


### PR DESCRIPTION
Added `lengthCheck` function to allow conditional rendering based on a vars length property.

Renamed `match` to `_` to save chars, as the variable isn't used.

Redefined `context` as `block(context)` in block function to only call the function once (it's used everywhere) and reduce number of characters used in running that logic.

Separated function logic out of ternary to `logic` variable for easy updating in conditionals

Minimal file size increase:
2135 bytes -> 2404 bytes (+269 bytes)